### PR TITLE
Fixup regex

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -19,12 +19,6 @@ class Xmllint(Linter):
 
     syntax = 'xml'
     cmd = 'xmllint --noout * -'
-    regex = (
-        r'^.+?:'
-        r'(?P<line>\d+):.+?: '
-        r'(?P<message>[^\r\n]+)\r?\n'
-        r'[^\r\n]*\r?\n'
-        r'(?P<col>[^\^]*)\^'
-    )
+    regex = r'^-:(?P<line>\d+):.+?: (?P<message>[^\r\n]+)(\r?\n[^\r\n]*\r?\n(?P<col>[^\^]*)\^)?'
     multiline = True
     error_stream = util.STREAM_STDERR


### PR DESCRIPTION
Since we're linting via stdin, the reported file by xmllint should be '-', all
other files will be ignored. Fixes #9

Make col matching optional. Fixes #7